### PR TITLE
feat: remove babel jsesc workaround

### DIFF
--- a/src/react-compiler-loader.ts
+++ b/src/react-compiler-loader.ts
@@ -21,15 +21,6 @@ export default async function reactCompilerLoader(this: webpack.LoaderContext<Re
       sourceFileName: this.resourcePath,
       filename: this.resourcePath,
       cloneInputAst: false,
-      generatorOpts: {
-        ...babelTransFormOpt?.generatorOpts,
-        // https://github.com/facebook/react/issues/29120
-        // TODO: remove once React Compiler has provided their workaround
-        jsescOption: {
-          minimal: true,
-          ...babelTransFormOpt?.generatorOpts?.jsescOption
-        }
-      },
       // user configured babel option
       ...babelTransFormOpt,
       // override babel plugins

--- a/test/__snapshots__/index.ts.snap
+++ b/test/__snapshots__/index.ts.snap
@@ -9,7 +9,7 @@ export default function Comp() {
     let t0;
     if ($[0] === Symbol.for(\\"react.memo_cache_sentinel\\")) {
         t0 = /*#__PURE__*/ _jsx(\\"div\\", {
-            \\"aria-label\\": \\"我能吞下玻璃而不伤身体\\",
+            \\"aria-label\\": \\"\\\\u6211\\\\u80FD\\\\u541E\\\\u4E0B\\\\u73BB\\\\u7483\\\\u800C\\\\u4E0D\\\\u4F24\\\\u8EAB\\\\u4F53\\",
             children: \\"我能吞下玻璃而不伤身体\\"
         });
         $[0] = t0;
@@ -165,7 +165,7 @@ export default function Comp() {
     let t0;
     if ($[0] === Symbol.for(\\"react.memo_cache_sentinel\\")) {
         t0 = /*#__PURE__*/ _jsx(\\"div\\", {
-            \\"aria-label\\": \\"我能吞下玻璃而不伤身体\\",
+            \\"aria-label\\": \\"\\\\u6211\\\\u80FD\\\\u541E\\\\u4E0B\\\\u73BB\\\\u7483\\\\u800C\\\\u4E0D\\\\u4F24\\\\u8EAB\\\\u4F53\\",
             children: \\"我能吞下玻璃而不伤身体\\"
         });
         $[0] = t0;


### PR DESCRIPTION
Since https://github.com/facebook/react/issues/29120 has been fixed and closed, we could remove the workaround.