### PR TITLE
fix(compiler): add missing target version type to ReactCompilerConfig

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -92,5 +92,5 @@ export interface ReactCompilerConfig {
    * versions prior to 19, an extra runtime package react-compiler-runtime is necessary to provide
    * a userspace approximation of runtime APIs.
    */
-  target?:  '17' | '18' | '19'
+  target?:  '17' | '18' | '19' | (string & {})
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,5 +84,13 @@ export interface ReactCompilerConfig {
    */
   ignoreUseNoForget?: boolean,
 
-  sources?: string[] | ((filename: string) => boolean) | null
+  sources?: string[] | ((filename: string) => boolean) | null,
+
+  /*
+   * The minimum major version of React that the compiler should emit code for. If the target is 19
+   * or higher, the compiler emits direct imports of React runtime APIs needed by the compiler. On
+   * versions prior to 19, an extra runtime package react-compiler-runtime is necessary to provide
+   * a userspace approximation of runtime APIs.
+   */
+  target?:  '17' | '18' | '19'
 };


### PR DESCRIPTION
Add type definition for target option (17|18|19) to fix TypeScript errors when configuring React version for runtime APIs

https://react.dev/learn/react-compiler#using-react-compiler-with-react-17-or-18