### PR TITLE
defineReactCompilerLoaderOption returns options under reactCompilerConfig key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import type { RuleSetRule } from 'webpack';
 
 type RuleOptions = Omit<RuleSetRule, 'use'>;
 
-export const defineReactCompilerLoaderOption = (options: ReactCompilerLoaderOption) => options;
+export const defineReactCompilerLoaderOption = (options: ReactCompilerLoaderOption) => ({ reactCompilerConfig: options });
 
 export function withReactCompiler(pluginOptions?: ReactCompilerLoaderOption, ruleOptions: RuleOptions = {}) {
   return (nextConfig: NextConfig = {}) => {


### PR DESCRIPTION
Hello,

I was following the README and realized `defineReactCompilerLoaderOption` wasn't doing anything. I believe this was the original intent of the function. 

Apologies for not writing any tests, I wasn't able to get the test suite to run for some reason, but figured this change was probably simple enough. Thank you!