### PR TITLE
fix: Accept partial plugin options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import type { RuleSetRule } from 'webpack';
 
 type RuleOptions = Omit<RuleSetRule, 'use'>;
 
-export const defineReactCompilerLoaderOption = (options: ReactCompilerLoaderOption) => options;
+export const defineReactCompilerLoaderOption = (options: Partial<ReactCompilerLoaderOption>) => options;
 
 export function withReactCompiler(pluginOptions?: ReactCompilerLoaderOption, ruleOptions: RuleOptions = {}) {
   return (nextConfig: NextConfig = {}) => {


### PR DESCRIPTION
Resolves #9 

Currently the [`PluginOptions`](https://github.com/facebook/react/blob/428ab8200128d9421828dbe644c3448d21ea8c45/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts#L49) exported by `babel-plugin-react-compiler` expects most keys to be populated but in reality the babel plugin accepts partial objects, so it would be better if `defineReactCompilerLoaderOption` accepted `Partial<PluginOptions>`.

`defineReactCompilerLoaderOption({ target: '17' })` is valid but the types won't accept it.

<img width="763" alt="Screenshot 2025-06-09 at 16 30 27" src="https://github.com/user-attachments/assets/ee48c68c-b1a8-4e08-808d-eefbb2a2d9d6" />

As a workaround, users can just set `options: { target: '17' },` but then you lose typing.
