### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "react-compiler-webpack",
   "version": "1.0.1",
   "description": "The webpack/Next.js Plugin for React Compiler",
+  "homepage": "https://github.com/SukkaW/react-compiler-webpack#readme",
   "repository": "https://github.com/SukkaW/react-compiler-webpack",
+  "bugs": {
+    "url": "https://github.com/SukkaW/react-compiler-webpack/issues"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- add npm homepage metadata pointing to the repository README
- add npm bugs.url metadata pointing to the GitHub issue tracker
- leave runtime code, dependencies, version, entry points, and published files unchanged

## Validation
- node package metadata assertion
- corepack pnpm install --frozen-lockfile --ignore-scripts
- corepack pnpm build
- corepack pnpm lint (passes with existing source warnings only)
- npm pack --dry-run --json
- git diff --check

Note: corepack pnpm test currently fails on snapshot sourceMappingURL differences because the checked-in snapshots include an absolute /Users/sukka/... source path, while this checkout is under /Users/yfengj/.... The failing snapshots are unrelated to this package metadata-only change.