### PR TITLE
chore: add homepage and bugs metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.1",
   "description": "The webpack/Next.js Plugin for React Compiler",
   "repository": "https://github.com/SukkaW/react-compiler-webpack",
+  "homepage": "https://github.com/SukkaW/react-compiler-webpack#readme",
+  "bugs": {
+    "url": "https://github.com/SukkaW/react-compiler-webpack/issues"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Add missing npm metadata fields (`homepage` and `bugs`) to the `react-compiler-webpack` package manifest.

Currently, `npm view react-compiler-webpack` returns `repository` and `license` but omits `homepage` and `bugs`, making it harder for users to find the README and issue tracker from the npm registry.

### Changes

- Added `homepage` field pointing to the repository README
- Added `bugs.url` field pointing to the GitHub issue tracker

No runtime code, dependencies, entry points, or published files are affected. This is a metadata-only change.

Ref: charles-openclaw/charles-microbounties#1612